### PR TITLE
PLUGIN-82: Fixed problem with Upsert operation in BigQuery Sink plugin.

### DIFF
--- a/docs/BigQueryTable-batchsink.md
+++ b/docs/BigQueryTable-batchsink.md
@@ -51,6 +51,10 @@ Should only be used with the Insert operation.
 
 **Table Key**: List of fields that determines relation between tables during Update and Upsert operations.
 
+**Dedupe By**: Column names and sort order used to choose which input record to update/upsert when there are 
+multiple input records with the same key. For example, if this is set to 'updated_time desc', then if there are 
+multiple input records with the same key, the one with the largest value for 'updated_time' will be applied.              
+
 **Create Partitioned Table**: Whether to create the BigQuery table with time partitioning. This value 
 is ignored if the table already exists.
 * When this is set to true, table will be created with time partitioning. 

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQuerySink.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQuerySink.java
@@ -155,6 +155,9 @@ public final class BigQuerySink extends AbstractBigQuerySink {
     if (config.getRelationTableKey() != null) {
       baseConfiguration.set(BigQueryConstants.CONFIG_TABLE_KEY, getConfig().getRelationTableKey());
     }
+    if (config.getDedupeBy() != null) {
+      baseConfiguration.set(BigQueryConstants.CONFIG_DEDUPE_BY, getConfig().getDedupeBy());
+    }
   }
 
   /**

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/util/BigQueryConstants.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/util/BigQueryConstants.java
@@ -31,5 +31,6 @@ public interface BigQueryConstants {
   String CONFIG_CLUSTERING_ORDER = "cdap.bq.sink.clustering.order";
   String CONFIG_OPERATION = "cdap.bq.sink.operation";
   String CONFIG_TABLE_KEY = "cdap.bq.sink.table.key";
+  String CONFIG_DEDUPE_BY = "cdap.bq.sink.dedupe.by";
   String CONFIG_TABLE_FIELDS = "cdap.bq.sink.table.fields";
 }

--- a/widgets/BigQueryTable-batchsink.json
+++ b/widgets/BigQueryTable-batchsink.json
@@ -95,6 +95,16 @@
           "widget-attributes" : {}
         },
         {
+          "name": "dedupeBy",
+          "label": "Dedupe By",
+          "widget-type": "keyvalue-dropdown",
+          "widget-attributes": {
+            "delimiter": ",",
+            "kv-delimiter": " ",
+            "dropdownOptions": [ "ASC", "DESC"]
+          }
+        },
+        {
           "widget-type": "toggle",
           "name": "truncateTable",
           "label": "Truncate Table",


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/PLUGIN-82

In scope of this PR:
- Fixed problem with handling duplicates.
- Added additional validation for 'Table key' field for checking duplicate fields.
- Added validation for new field 'Ordered by'.